### PR TITLE
Fixes issue with filters not working after my last PR

### DIFF
--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -1,17 +1,18 @@
-!!! 5
+!!! 5{lang: I18n.locale}
 %html
   %head
+    %meta{content: "IE=edge", "http-equiv" => "X-UA-Compatible"}
     %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}
     %meta{content: "NONE,NOARCHIVE", name: "robots"}
     = csrf_meta_tag
     = stylesheet_link_tag "rails_admin/rails_admin.css", media: :all
-    = stylesheet_link_tag "rails_admin/bootstrap/bootstrap-select"
+    = #stylesheet_link_tag "rails_admin/bootstrap/bootstrap-select"
     = javascript_include_tag "rails_admin/rails_admin.js"
     = # javascript_include_tag "//www.google.com/jsapi", "chartkick"
     = javascript_include_tag "rails_admin/highcharts.js", "chartkick"
     -# Initialize JS simple i18n
     :javascript
-      RailsAdmin.I18n.init(JSON.parse("#{j I18n.t("admin.js").to_json}"))
+      RailsAdmin.I18n.init('#{I18n.locale}', JSON.parse("#{j I18n.t("admin.js").to_json}"))
   %body.rails_admin
     #loading.label.label-warning{style: 'display:none; position:fixed; right:20px; bottom:20px; z-index:100000'}= t('admin.loading')
     %nav.navbar.navbar-default.navbar-fixed-top


### PR DESCRIPTION
There is still an issue in 0.8.1 where filters will dissapear after being applied. However they do work the first time the page refreshes after creating them. So as a work around you just have to re-apply them each time you want to change them. I will keep looking into this but for now this is the best working version with rails_admin 0.8.1